### PR TITLE
[OPS-808] add option for forcing oauth chooser

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,8 @@ An example [oauth2_proxy.cfg](contrib/oauth2_proxy.cfg.example) config file is i
 
 ```
 Usage of oauth2_proxy:
-  -approval-prompt string: OAuth approval_prompt (default "force")
+  -account-chooser bool: force google account chooser (default false)
+  -approval-prompt bool: force OAuth approval_prompt (default true)
   -authenticated-emails-file string: authenticate against emails via file (one per line)
   -azure-tenant string: go to a tenant-specific or common (tenant-independent) endpoint. (default "common")
   -basic-auth-password string: the password to set when passing the HTTP Basic Auth header

--- a/options.go
+++ b/options.go
@@ -82,7 +82,8 @@ type Options struct {
 	ProtectedResource string `flag:"resource" cfg:"resource" env:"OAUTH2_PROXY_RESOURCE"`
 	ValidateURL       string `flag:"validate-url" cfg:"validate_url" env:"OAUTH2_PROXY_VALIDATE_URL"`
 	Scope             string `flag:"scope" cfg:"scope" env:"OAUTH2_PROXY_SCOPE"`
-	ApprovalPrompt    string `flag:"approval-prompt" cfg:"approval_prompt" env:"OAUTH2_PROXY_APPROVAL_PROMPT"`
+	ApprovalPrompt    bool   `flag:"approval-prompt" cfg:"approval_prompt" env:"OAUTH2_PROXY_APPROVAL_PROMPT"`
+	AccountChooser    bool   `flag:"account-chooser" cfg:"account_chooser" env:"OAUTH2_PROXY_ACCOUNT_CHOOSER"`
 
 	RequestLogging       bool   `flag:"request-logging" cfg:"request_logging" env:"OAUTH2_PROXY_REQUEST_LOGGING"`
 	RequestLoggingFormat string `flag:"request-logging-format" cfg:"request_logging_format" env:"OAUTH2_PROXY_REQUEST_LOGGING_FORMAT"`
@@ -129,7 +130,8 @@ func NewOptions() *Options {
 		PassHostHeader:       true,
 		SetAuthorization:     false,
 		PassAuthorization:    false,
-		ApprovalPrompt:       "force",
+		ApprovalPrompt:       true,
+		AccountChooser:       false,
 		RequestLogging:       true,
 		SkipOIDCDiscovery:    false,
 		RequestLoggingFormat: defaultRequestLoggingFormat,
@@ -297,6 +299,7 @@ func parseProviderInfo(o *Options, msgs []string) []string {
 		ClientID:       o.ClientID,
 		ClientSecret:   o.ClientSecret,
 		ApprovalPrompt: o.ApprovalPrompt,
+		AccountChooser: o.AccountChooser,
 	}
 	p.LoginURL, msgs = parseURL(o.LoginURL, "login", msgs)
 	p.RedeemURL, msgs = parseURL(o.RedeemURL, "redeem", msgs)

--- a/providers/logingov.go
+++ b/providers/logingov.go
@@ -263,7 +263,9 @@ func (p *LoginGovProvider) GetLoginURL(redirectURI, state string) string {
 	a = *p.LoginURL
 	params, _ := url.ParseQuery(a.RawQuery)
 	params.Set("redirect_uri", redirectURI)
-	params.Set("approval_prompt", p.ApprovalPrompt)
+  if p.ApprovalPrompt {
+	   params.Set("approval_prompt", "force")
+  }
 	params.Add("scope", p.Scope)
 	params.Set("client_id", p.ClientID)
 	params.Set("response_type", "code")

--- a/providers/provider_data.go
+++ b/providers/provider_data.go
@@ -16,7 +16,8 @@ type ProviderData struct {
 	ProtectedResource *url.URL
 	ValidateURL       *url.URL
 	Scope             string
-	ApprovalPrompt    string
+	ApprovalPrompt    bool
+	AccountChooser    bool
 }
 
 // Data returns the ProviderData

--- a/providers/provider_default.go
+++ b/providers/provider_default.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+  "strings"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -84,7 +85,15 @@ func (p *ProviderData) GetLoginURL(redirectURI, state string) string {
 	a = *p.LoginURL
 	params, _ := url.ParseQuery(a.RawQuery)
 	params.Set("redirect_uri", redirectURI)
-	params.Set("approval_prompt", p.ApprovalPrompt)
+  prompt := []string{}
+  if p.ApprovalPrompt {
+    prompt = append(prompt, "consent")
+  } else if p.AccountChooser {
+    prompt = append(prompt, "select_account")
+  }
+  if len(prompt) > 0 {
+    params.Set("prompt", strings.Join(prompt, " "))
+  }
 	params.Add("scope", p.Scope)
 	params.Set("client_id", p.ClientID)
 	params.Set("response_type", "code")


### PR DESCRIPTION
Things used for reference:

- https://stackoverflow.com/questions/14384354/force-google-account-chooser
- https://stackoverflow.com/questions/10508557/why-does-google-oauth2-re-ask-user-for-permission-when-i-send-them-to-auth-url-a

This might have the effect of it asking for consent every time now that the approval prompt option works again. Might want to turn that off.